### PR TITLE
Improve convenience and tests

### DIFF
--- a/chx_compress/tests/conftest.py
+++ b/chx_compress/tests/conftest.py
@@ -1,0 +1,89 @@
+import io
+
+import numpy as np
+import sparse
+
+import pytest
+
+from chx_compress.io.multifile.multifile import (
+    MultifileWriter,
+    write_sparse_coo_to_multifile,
+)
+
+
+@pytest.fixture()
+def dense_data_factory():
+    """Return a factory function that builds a ndarray of random values.
+
+    The returned array is meant to resemble CHX detector data.  It has
+    shape FRAMES x ROWS x COLUMNS. By default some of the random values
+    will be zero.
+    """
+    rng = np.random.default_rng()
+
+    def _sparse_data_factory(
+        frame_count, row_count, column_count, low_value=0, high_value=3
+    ):
+        # sparse_data is meant to resemble CHX detector data
+        sparse_data = rng.integers(
+            low=low_value,
+            high=high_value,
+            size=frame_count * row_count * column_count,
+            dtype=np.uint32,
+        )
+        sparse_data = sparse_data.reshape((frame_count, row_count, column_count))
+
+        return sparse_data
+
+    return _sparse_data_factory
+
+
+@pytest.fixture()
+def header_info_factory():
+    """ Return a factory function that builds a multifile header dictionary. """
+    def _header_info_factory(byte_count, row_count, column_count):
+        header_info = {
+            "byte_count": byte_count,
+            "beam_center_x": 1143.0,
+            "beam_center_y": 1229.0,
+            "count_time": 0.001997,
+            "detector_distance": 16235.550295,
+            "frame_time": 0.002,
+            "incident_wavelength": 1.28507668359453,
+            "x_pixel_size": 7.5e-05,
+            "y_pixel_size": 7.5e-05,
+            "nrows": row_count,
+            "ncols": column_count,
+            "rows_begin": 0,
+            "rows_end": row_count,
+            "cols_begin": 0,
+            "cols_end": column_count,
+        }
+        return header_info
+
+    return _header_info_factory
+
+
+@pytest.fixture()
+def multifile_bytes_factory(dense_data_factory, header_info_factory):
+    """ Return a factory function that builds a multifile. """
+    def _multifile_factory(
+        byte_count, frame_count, row_count, column_count, low_value=0, high_value=3
+    ):
+        header_info = header_info_factory(byte_count, row_count, column_count)
+
+        dense_data = dense_data_factory(
+            frame_count, row_count, column_count, low_value, high_value
+        )
+        sparse_coo_data = sparse.COO(dense_data)
+
+        with MultifileWriter(io.BytesIO(), **header_info) as multifile_writer:
+            write_sparse_coo_to_multifile(
+                sparse_coo_array=sparse_coo_data, multifile_writer=multifile_writer
+            )
+
+            multifile_bytes = multifile_writer._write_buffer.getvalue()
+
+        return multifile_bytes, header_info, sparse_coo_data
+
+    return _multifile_factory

--- a/chx_compress/tests/test_export_sparse_to_multifile.py
+++ b/chx_compress/tests/test_export_sparse_to_multifile.py
@@ -6,15 +6,11 @@ import sparse
 import pytest
 
 
-from chx_compress.io.multifile.multifile import (
-    MultifileReader,
-    MultifileWriter,
-    write_sparse_coo_to_multifile,
-)
+from chx_compress.io.multifile.multifile import MultifileReader
 
 
 @pytest.mark.parametrize("byte_count", (2, 4, 8))
-def test_sparse_to_multifile_export(byte_count):
+def test_sparse_to_multifile_export(multifile_bytes_factory, byte_count):
     """Export a sparse.COO array as a multifile.
 
     This is as much a demonstration as a test.
@@ -27,61 +23,23 @@ def test_sparse_to_multifile_export(byte_count):
     row_count = 3
     column_count = 5
 
-    # detector_data is meant to resemble CHX detector data
-    rng = np.random.default_rng()
-    detector_data = rng.integers(
-        low=0, high=3, size=frame_count * row_count * column_count, dtype=np.uint32
+    multifile_bytes, header_info, sparse_detector_data = multifile_bytes_factory(
+        byte_count=byte_count,
+        frame_count=frame_count,
+        row_count=row_count,
+        column_count=column_count,
     )
-    detector_data = detector_data.reshape((frame_count, row_count, column_count))
-
-    # create a sparse.COO version
-    sparse_detector_data = sparse.COO(detector_data)
-
-    # write a multifile
-    header_info = {
-        "byte_count": byte_count,
-        "beam_center_x": 1143.0,
-        "beam_center_y": 1229.0,
-        "count_time": 0.001997,
-        "detector_distance": 16235.550295,
-        "frame_time": 0.002,
-        "incident_wavelength": 1.28507668359453,
-        "x_pixel_size": 7.5e-05,
-        "y_pixel_size": 7.5e-05,
-        "nrows": row_count,
-        "ncols": column_count,
-        "rows_begin": 0,
-        "rows_end": row_count,
-        "cols_begin": 0,
-        "cols_end": column_count,
-    }
-
-    # starting from a sparse.COO array, write a multifile
-    with MultifileWriter(BufferedRandom(BytesIO()), **header_info) as multifile_writer:
-
-        write_sparse_coo_to_multifile(
-            sparse_coo_array=sparse_detector_data, multifile_writer=multifile_writer
-        )
-
-        multifile_writer._write_buffer.flush()
-        the_data_we_wrote = multifile_writer._write_buffer.raw.getvalue()
 
     # starting from a multifile, reconstruct a numpy array
     #   and compare it to the sparse.COO array
     recovered_detector_data = np.zeros((frame_count, row_count, column_count))
     with MultifileReader(
-        BufferedRandom(BytesIO(initial_bytes=the_data_we_wrote))
+        BufferedRandom(BytesIO(initial_bytes=multifile_bytes))
     ) as multifile_reader:
         assert multifile_reader.version_info == b"Version-COMP0001"
         assert multifile_reader.header_info == header_info
         assert len(multifile_reader) == sparse_detector_data.shape[0]
 
-        recovered_image_array = np.zeros(
-            (
-                multifile_reader.header_info["nrows"],
-                multifile_reader.header_info["ncols"],
-            )
-        )
         for image_i, (recovered_pixel_indices, recovered_pixel_values) in enumerate(
             multifile_reader
         ):
@@ -92,13 +50,14 @@ def test_sparse_to_multifile_export(byte_count):
             assert np.array_equal(sparse_image_linear_indices, recovered_pixel_indices)
             assert np.array_equal(sparse_image.data, recovered_pixel_values)
 
-            recovered_image_array[:] = 0
             np.put(
-                recovered_image_array, recovered_pixel_indices, recovered_pixel_values
+                recovered_detector_data[image_i],
+                recovered_pixel_indices,
+                recovered_pixel_values,
             )
             # np.array_equal does not work with sparse arrays
-            assert np.array_equal(sparse_image.todense(), recovered_image_array)
-
-            recovered_detector_data[image_i] = recovered_image_array
+            assert np.array_equal(
+                sparse_image.todense(), recovered_detector_data[image_i]
+            )
 
     assert np.array_equal(recovered_detector_data, sparse_detector_data.todense())

--- a/chx_compress/tests/test_get_dense_array.py
+++ b/chx_compress/tests/test_get_dense_array.py
@@ -1,0 +1,21 @@
+import io
+
+import numpy as np
+
+import pytest
+
+from chx_compress.io.multifile.multifile import get_dense_array, MultifileReader
+
+
+@pytest.mark.parametrize("byte_count", (2, 4, 8))
+def test_get_dense_array(multifile_bytes_factory, byte_count):
+    multifile_bytes, _, sparse_data = multifile_bytes_factory(
+        byte_count=byte_count, frame_count=10, row_count=20, column_count=30
+    )
+
+    with MultifileReader(
+        read_buffer=io.BufferedRandom(io.BytesIO(initial_bytes=multifile_bytes))
+    ) as multifile_reader:
+        dense_data = get_dense_array(multifile_reader=multifile_reader)
+
+        assert np.array_equal(dense_data, sparse_data.todense())

--- a/chx_compress/tests/test_multifile.py
+++ b/chx_compress/tests/test_multifile.py
@@ -1,5 +1,4 @@
 import itertools
-import os
 
 from io import BufferedRandom, BytesIO
 
@@ -9,40 +8,23 @@ import pytest
 from chx_compress.io.multifile.multifile import (
     MultifileReader,
     MultifileWriter,
-    multifile_reader,
 )
 
 
 @pytest.mark.parametrize("byte_count", (2, 4, 8))
-def test_multifile_with_no_images(byte_count):
+def test_multifile_with_no_images(header_info_factory, byte_count):
+    """
+    A strange but testable situation.
+    """
+    header_info = header_info_factory(
+        byte_count=byte_count, row_count=2070, column_count=2167
+    )
 
-    header_info = {
-        "byte_count": byte_count,
-        "beam_center_x": 1143.0,
-        "beam_center_y": 1229.0,
-        "count_time": 0.001997,
-        "detector_distance": 16235.550295,
-        "frame_time": 0.002,
-        "incident_wavelength": 1.28507668359453,
-        "x_pixel_size": 7.5e-05,
-        "y_pixel_size": 7.5e-05,
-        "nrows": 2070,
-        "ncols": 2167,
-        "rows_begin": 0,
-        "rows_end": 2070,
-        "cols_begin": 0,
-        "cols_end": 2167,
-    }
-
-    with MultifileWriter(
-        BufferedRandom(BytesIO()), **header_info
-    ) as multifile_writer:
+    with MultifileWriter(BufferedRandom(BytesIO()), **header_info) as multifile_writer:
 
         # at this point the multifile header has been written
 
-        with MultifileReader(
-            multifile_writer._write_buffer
-        ) as multifile_reader:
+        with MultifileReader(multifile_writer._write_buffer) as multifile_reader:
             assert multifile_reader.version_info == b"Version-COMP0001"
             assert multifile_reader.header_info == header_info
             assert len(multifile_reader) == 0
@@ -60,7 +42,7 @@ def test_multifile_with_no_images(byte_count):
 @pytest.mark.parametrize(
     "byte_count,image_count", itertools.product((2, 4, 8), (0, 1, 2))
 )
-def test_write_read(byte_count, image_count):
+def test_write_read(header_info_factory, byte_count, image_count):
     """
     Write a multifile to a buffer, then read a multifile from that buffer.
 
@@ -73,27 +55,11 @@ def test_write_read(byte_count, image_count):
     """
 
     # byte_count is the only value that changes in header_info
-    header_info = {
-        "byte_count": byte_count,
-        "beam_center_x": 1143.0,
-        "beam_center_y": 1229.0,
-        "count_time": 0.001997,
-        "detector_distance": 16235.550295,
-        "frame_time": 0.002,
-        "incident_wavelength": 1.28507668359453,
-        "x_pixel_size": 7.5e-05,
-        "y_pixel_size": 7.5e-05,
-        "nrows": 2070,
-        "ncols": 2167,
-        "rows_begin": 0,
-        "rows_end": 2070,
-        "cols_begin": 0,
-        "cols_end": 2167,
-    }
+    header_info = header_info_factory(
+        byte_count=byte_count, row_count=2070, column_count=2167
+    )
 
-    with MultifileWriter(
-        BufferedRandom(BytesIO()), **header_info
-    ) as multifile_writer:
+    with MultifileWriter(BufferedRandom(BytesIO()), **header_info) as multifile_writer:
 
         written_data = []
         # write image_count images in the multifile
@@ -143,7 +109,6 @@ def test_write_read(byte_count, image_count):
     multifile_reader = MultifileReader(
         BufferedRandom(BytesIO(initial_bytes=the_data_we_wrote))
     )
-    multifile_reader.read_header_and_offsets()
     assert multifile_reader.version_info == b"Version-COMP0001"
     assert multifile_reader.header_info == header_info
     assert len(multifile_reader) == image_count
@@ -159,30 +124,3 @@ def test_write_read(byte_count, image_count):
     multifile_reader.close()
 
     assert multifile_reader._read_buffer.closed
-
-
-@pytest.mark.skipif(
-    not os.path.exists("/nsls2/data/chx/legacy/Compressed_Data"),
-    reason="compressed data files are not available",
-)
-def test_read_a_real_file():
-    """ Read a real file.
-
-    This test may take up to 3 minutes.
-    """
-    with multifile_reader(
-        "/nsls2/data/chx/legacy/Compressed_Data/uid_0014eb14-9373-4a6c-915a-041f5cc6da96.cmp",
-    ) as mfr:
-
-        byte_count = mfr.header_info["byte_count"]
-        assert byte_count == 4
-
-        # read the first image
-        pixel_indices, pixel_values = mfr[0]
-        assert pixel_values[0] == 1
-
-        # read all the images
-        image_array = np.zeros((mfr.header_info["nrows"], mfr.header_info["ncols"]))
-        for pixel_indices, pixel_values in mfr:
-            image_array[:] = 0
-            np.put(image_array, pixel_indices, pixel_values)

--- a/chx_compress/tests/test_read_real_file.py
+++ b/chx_compress/tests/test_read_real_file.py
@@ -1,0 +1,32 @@
+import os
+
+import pytest
+
+from chx_compress.io.multifile.multifile import multifile_reader
+
+
+@pytest.mark.skipif(
+    not os.path.exists("/nsls2/data/chx/legacy/Compressed_Data"),
+    reason="compressed data files are not available",
+)
+def test_read_a_real_file():
+    """Read a real file.
+
+    This test may take up to 3 minutes.
+    """
+    with multifile_reader(
+        "/nsls2/data/chx/legacy/Compressed_Data/uid_0014eb14-9373-4a6c-915a-041f5cc6da96.cmp",
+    ) as mfr:
+
+        byte_count = mfr.header_info["byte_count"]
+        assert byte_count == 4
+
+        # read the first image
+        pixel_indices, pixel_values = mfr[0]
+        assert pixel_values[0] == 1
+
+        # read all the images
+        image_array = np.zeros((mfr.header_info["nrows"], mfr.header_info["ncols"]))
+        for pixel_indices, pixel_values in mfr:
+            image_array[:] = 0
+            np.put(image_array, pixel_indices, pixel_values)


### PR DESCRIPTION
This PR improves the convenience of direct usage of MultifileReader by reading the header and image offsets on construction rather than requiring a separate function call.

In addition a convenience function was added to return a dense array from a MultifileReader.

Test fixtures and new tests have been added.